### PR TITLE
REFACTOR : 이메일 인증 처리를 수정하자

### DIFF
--- a/component/profile/account/basic-information/BasicInformation.component.js
+++ b/component/profile/account/basic-information/BasicInformation.component.js
@@ -248,16 +248,7 @@ const BasicInformationComponent = (props) => {
                 e.preventDefault();
                 if (__userInfo.verify.form()) {
                     props.onSubmitUpdateUserInfo(userInfo);
-
-                    setIsEmailAddressChanged(false);
-                    setIsEmailAuthNumberRequest(false);
-                    dispatchUserInfo({
-                        type: 'CHANGE_DATA',
-                        payload: {
-                            name: 'emailAuthNumber',
-                            value: ''
-                        }
-                    })
+                    __userInfo.action.onActionResetEmailAuth();
                 }
             }
         },
@@ -293,8 +284,16 @@ const BasicInformationComponent = (props) => {
                 setIsEmailAddressChanged(!isEmailAddressChanged);
             },
             onActionResetEmailAuth: () => {
-                setIsEmailAddressChanged(true);
+                setIsEmailAddressChanged(false);
                 setIsEmailAuthNumberRequest(false);
+
+                dispatchUserInfo({
+                    type: 'CHANGE_DATA',
+                    payload: {
+                        name: 'emailAuthNumber',
+                        value: ''
+                    }
+                })
                 props.onActionResetVerifiedEmail();
             },
             getEmailAuthNumber: () => {

--- a/component/profile/account/basic-information/BasicInformation.component.js
+++ b/component/profile/account/basic-information/BasicInformation.component.js
@@ -170,17 +170,15 @@ const BasicInformationComponent = (props) => {
     }, [props.userInfo, userInfo])
 
     useEffect(() => {
-        if(props.isVerifiedEmail) {
-            setIsEmailAddressChanged(false);
-            setIsEmailAuthNumberRequest(false);
-            dispatchUserInfo({
-                type: 'CHANGE_DATA',
-                payload: {
-                    name: 'emailAuthNumber',
-                    value: ''
-                }
-            })
-        }
+        setIsEmailAddressChanged(false);
+        setIsEmailAuthNumberRequest(false);
+        dispatchUserInfo({
+            type: 'CHANGE_DATA',
+            payload: {
+                name: 'emailAuthNumber',
+                value: ''
+            }
+        })
     }, [props.isVerifiedEmail])
 
     useEffect(() => {
@@ -250,6 +248,16 @@ const BasicInformationComponent = (props) => {
                 e.preventDefault();
                 if (__userInfo.verify.form()) {
                     props.onSubmitUpdateUserInfo(userInfo);
+
+                    setIsEmailAddressChanged(false);
+                    setIsEmailAuthNumberRequest(false);
+                    dispatchUserInfo({
+                        type: 'CHANGE_DATA',
+                        payload: {
+                            name: 'emailAuthNumber',
+                            value: ''
+                        }
+                    })
                 }
             }
         },

--- a/component/profile/account/basic-information/BasicInformation.component.js
+++ b/component/profile/account/basic-information/BasicInformation.component.js
@@ -1,3 +1,4 @@
+import { identity } from 'lodash';
 import { useEffect, useReducer, useState } from 'react';
 import { checkEmailFormat, checkNameForm, checkNicknameForm, checkPhoneNumberFormat } from '../../../../utils/regexUtils';
 import { ButtonFieldWrapper, Container, FormFieldWrapper, TitleFieldWrapper } from './BasicInformation.styled';
@@ -10,7 +11,8 @@ function TitleFieldView() {
     );
 }
 
-function FormFieldView({ userInfo, isEmailAuthNumberRequest, isPhoneAuthNumberRequest,
+function FormFieldView({ userInfo, isEmailAddressChanged, onChangeIsEmailAddressValue, onActionResetEmailAuth, 
+    isEmailAuthNumberRequest, isPhoneAuthNumberRequest,
     onChangeValue, onActionGetPhoneAuthNumber, onActionVerifyPhoneAuthNumber, onActionGetEmailAuthNumber, onActionVerifyEmailAuthNumber }) {
     return (
         <FormFieldWrapper>
@@ -52,25 +54,34 @@ function FormFieldView({ userInfo, isEmailAuthNumberRequest, isPhoneAuthNumberRe
                                 value={userInfo.email || ''}
                                 onChange={onChangeValue}
                                 required
+                                disabled={!isEmailAddressChanged}
                             ></input>
-                            <div className='input-notice'>이메일이 도착하지 않는다면 재요청해주세요.</div>
+                            <div className='input-notice'>회원 수정을 완료해야 이메일 정보가 변경됩니다.</div>
                         </div>
-                        <button type='button' onClick={onActionGetEmailAuthNumber}>인증번호 발급</button>
+                        {!isEmailAuthNumberRequest && !isEmailAddressChanged &&
+                            <button type='button' className='input-side-btn' onClick={() => onChangeIsEmailAddressValue()}>이메일 변경</button>
+                        }
+                        {!isEmailAuthNumberRequest && isEmailAddressChanged &&
+                            <button type='button' className='input-side-btn' onClick={() => onActionGetEmailAuthNumber()}>인증번호 받기</button>
+                        }
                     </div>
-                    <div className='auth-box'>
-                        <div className='input-el-box'>
-                            <input
-                                className='input-el'
-                                type='number'
-                                name='emailAuthNumber'
-                                value={userInfo.emailAuthNumber || ''}
-                                placeholder='인증번호'
-                                onChange={onChangeValue}
-                                disabled={!isEmailAuthNumberRequest}
-                            ></input>
+                    {isEmailAuthNumberRequest &&
+                        <div className='auth-box'>
+                            <div className='input-el-box'>
+                                <input
+                                    className='input-el'
+                                    type='number'
+                                    name='emailAuthNumber'
+                                    value={userInfo.emailAuthNumber || ''}
+                                    placeholder='인증번호'
+                                    onChange={onChangeValue}
+                                ></input>
+                                <div className='input-notice'>이메일이 도착하지 않는다면 재요청해주세요.</div>
+                                <div className='input-notice re-request' onClick={() => onActionResetEmailAuth()}>이메일 변경 및 재요청</div>
+                            </div>
+                            <button type='button' className='input-side-btn' onClick={onActionVerifyEmailAuthNumber}>인증</button>
                         </div>
-                        <button type='button' onClick={onActionVerifyEmailAuthNumber} disabled={!isEmailAuthNumberRequest}>확인</button>
-                    </div>
+                    }
                 </div>
                 <div className='input-box'>
                     <div className='input-label'>전화번호<span>(선택)</span></div>
@@ -85,7 +96,7 @@ function FormFieldView({ userInfo, isEmailAuthNumberRequest, isPhoneAuthNumberRe
                             ></input>
                             <div className='input-notice'>숫자만 입력해주세요.</div>
                         </div>
-                        <button type='button' onClick={onActionGetPhoneAuthNumber}>인증번호 발급</button>
+                        <button type='button' className='input-side-btn' onClick={onActionGetPhoneAuthNumber}>인증번호 발급</button>
                     </div>
                     <div className='auth-box'>
                         <div className='input-el-box'>
@@ -99,7 +110,7 @@ function FormFieldView({ userInfo, isEmailAuthNumberRequest, isPhoneAuthNumberRe
                                 disabled={!isPhoneAuthNumberRequest}
                             ></input>
                         </div>
-                        <button type='button' onClick={onActionVerifyPhoneAuthNumber} disabled={!isPhoneAuthNumberRequest}>확인</button>
+                        <button type='button' className='input-side-btn' onClick={onActionVerifyPhoneAuthNumber} disabled={!isPhoneAuthNumberRequest}>확인</button>
                     </div>
                 </div>
             </div>
@@ -159,27 +170,18 @@ const BasicInformationComponent = (props) => {
     }, [props.userInfo, userInfo])
 
     useEffect(() => {
-        if(!props.verifiedEmail) {
-            return;
+        if(props.isVerifiedEmail) {
+            setIsEmailAddressChanged(false);
+            setIsEmailAuthNumberRequest(false);
+            dispatchUserInfo({
+                type: 'CHANGE_DATA',
+                payload: {
+                    name: 'emailAuthNumber',
+                    value: ''
+                }
+            })
         }
-
-        dispatchUserInfo({
-            type: 'CHANGE_DATA',
-            payload: {
-                name: 'verifiedEmail',
-                value: props.verifiedEmail
-            }
-        })
-        dispatchUserInfo({
-            type: 'CHANGE_DATA',
-            payload: {
-                name: 'emailAuthNumber',
-                value: ''
-            }
-        })
-
-        setIsEmailAuthNumberRequest(false);
-    }, [props.verifiedEmail]);
+    }, [props.isVerifiedEmail])
 
     useEffect(() => {
         if(!props.verifiedPhoneNumber) {
@@ -203,22 +205,6 @@ const BasicInformationComponent = (props) => {
 
         setIsPhoneAuthNumberRequest(false);
     }, [props.verifiedPhoneNumber]);
-
-    useEffect(() => {
-        if(!isEmailAddressChanged) {
-            return;
-        }
-
-        dispatchUserInfo({
-            type: 'CHANGE_DATA',
-            payload: {
-                name: 'emailAuthNumber',
-                value: ''
-            }
-        })
-
-        setIsEmailAuthNumberRequest(false);
-    }, [isEmailAddressChanged]);
 
     useEffect(() => {
         if(!isPhoneNumberChanged) {
@@ -250,14 +236,6 @@ const BasicInformationComponent = (props) => {
                     }
                 })
 
-                if(e.target.name === 'email') {
-                    setIsEmailAddressChanged(true);
-
-                    if(e.target.value === '') {
-                        setIsEmailAddressChanged(false);
-                    }
-                }
-
                 if(e.target.name === 'phoneNumber') {
                     setIsPhoneNumberChanged(true);
 
@@ -287,16 +265,6 @@ const BasicInformationComponent = (props) => {
                     return false;
                 }
 
-                if ((props.userInfo.email !== userInfo.email) && !userInfo.verifiedEmail) {
-                    alert('이메일 인증을 완료해주세요.');
-                    return false;
-                }
-
-                if(userInfo.verifiedEmail && (userInfo.email !== userInfo.verifiedEmail)) {
-                    alert('이메일 인증이 올바르지 않습니다.');
-                    return false;
-                }
-
                 // 전화번호는 선택값
                 if (userInfo.phoneNumber){
                     if((props.userInfo.phoneNumber !== userInfo.phoneNumber) && !userInfo.verifiedPhoneNumber) {
@@ -312,7 +280,15 @@ const BasicInformationComponent = (props) => {
                 return true;
             }
         },
-        req: {
+        action: {
+            onChangeIsEmailAddressValue: () => {
+                setIsEmailAddressChanged(!isEmailAddressChanged);
+            },
+            onActionResetEmailAuth: () => {
+                setIsEmailAddressChanged(true);
+                setIsEmailAuthNumberRequest(false);
+                props.onActionResetVerifiedEmail();
+            },
             getEmailAuthNumber: () => {
                 if(!checkEmailFormat(userInfo.email)) {
                     alert('이메일 형식을 확인해 주세요.');
@@ -362,10 +338,12 @@ const BasicInformationComponent = (props) => {
                             isPhoneAuthNumberRequest={isPhoneAuthNumberRequest}
 
                             onChangeValue={__userInfo.change.valueOfName}
-                            onActionGetPhoneAuthNumber={__userInfo.req.getPhoneAuthNumber}
-                            onActionVerifyPhoneAuthNumber={__userInfo.req.verifyPhoneAuthNumber}
-                            onActionGetEmailAuthNumber={__userInfo.req.getEmailAuthNumber}
-                            onActionVerifyEmailAuthNumber={__userInfo.req.verifyEmailAuthNumber}
+                            onActionGetPhoneAuthNumber={__userInfo.action.getPhoneAuthNumber}
+                            onActionVerifyPhoneAuthNumber={__userInfo.action.verifyPhoneAuthNumber}
+                            onActionGetEmailAuthNumber={__userInfo.action.getEmailAuthNumber}
+                            onActionVerifyEmailAuthNumber={__userInfo.action.verifyEmailAuthNumber}
+                            onChangeIsEmailAddressValue={__userInfo.action.onChangeIsEmailAddressValue}
+                            onActionResetEmailAuth={__userInfo.action.onActionResetEmailAuth}
                         />
                         <ButtonFieldView
                             isChanged={isChanged}

--- a/component/profile/account/basic-information/BasicInformation.styled.js
+++ b/component/profile/account/basic-information/BasicInformation.styled.js
@@ -36,6 +36,13 @@ const FormFieldWrapper = styled.div`
         color: #707070;
         font-size: 12px;
         margin-top: 3px;
+        padding: 2px;
+    }
+
+    .re-request {
+        color: #2C73D2;
+        text-decoration: underline;
+        cursor: pointer;
     }
 
     .input-el{
@@ -48,9 +55,14 @@ const FormFieldWrapper = styled.div`
             outline: none;
             background: #2C73D20D;
         }
+
+        :disabled {
+            background: #e0e0e0;
+            border: 1px solid #e0e0e0;
+        }
     }
 
-    .input-box button {
+    .input-box .input-side-btn {
         padding: 10px;
         margin: 0 5px;
         border-radius: 2px;
@@ -64,6 +76,12 @@ const FormFieldWrapper = styled.div`
             cursor: not-allowed;
             background: #e0e0e0;
             border: 1px solid #e0e0e0;
+        }
+
+        transition: all .3s;
+        &:hover{
+            background: #309FFF;
+            border: 1px solid #309FFF;
         }
     }
 

--- a/component/profile/account/index.js
+++ b/component/profile/account/index.js
@@ -24,8 +24,8 @@ const ProfileAccountMainComponent = (props) => {
     const [snackbarMessage, setSnackbarMessage] = useState('no message');
     const [snackbarSeverity, setSnackbarSeverity] = useState('info');
     
+    const [isVerifiedEmail, setIsVerifiedEmail] = useState(false);
     const [verifiedPhoneNumber, setVerifiedPhoneNumber] = useState(null);
-    const [verifiedEmail, setVerifiedEmail] = useState(null);
 
     const __user = {
         req: {
@@ -41,7 +41,6 @@ const ProfileAccountMainComponent = (props) => {
                     })
             },
             updateInfo: async (body) => {
-                console.log(body);
                 await csrfDataConnect().getAuthCsrf();
                 await userDataConnect().updateInfo(body).then(res => {
                     if (res?.status === 200 && res?.data?.message === 'success') {
@@ -116,6 +115,7 @@ const ProfileAccountMainComponent = (props) => {
                     if (res?.status === 200 && res?.data?.message === 'success') {
                         setSnackbarSeverity('success');
                         _onSnackbarOpen('인증 요청되었습니다.');
+                        setIsVerifiedEmail(false);
                     }
                 }).catch(err => {
                     let res = err?.response;
@@ -134,7 +134,7 @@ const ProfileAccountMainComponent = (props) => {
                     if (res?.status === 200 && res?.data?.message === 'success') {
                         setSnackbarSeverity('success');
                         _onSnackbarOpen('인증되었습니다.');
-                        setVerifiedEmail(email);
+                        setIsVerifiedEmail(true);
                     }
                 }).catch(err => {
                     let res = err?.response;
@@ -146,18 +146,26 @@ const ProfileAccountMainComponent = (props) => {
 
                     setSnackbarSeverity('error');
                     _onSnackbarOpen(res?.data?.memo);
-                    setVerifiedEmail(null);
                 });
             }
         },
         submit: {
             updateInfo: async (body) => {
-                await __user.req.updateInfo(body);
+                let data = {
+                    ...body,
+                    verifiedEmail : isVerifiedEmail
+                }
+                await __user.req.updateInfo(data);
                 await __user.req.fetchData();
             },
             changePassword: async (body) => {
                 await __user.req.changePassword(body);
                 await __user.req.fetchData();
+            }
+        },
+        action: {
+            onActionResetVerifiedEmail: () => {
+                setIsVerifiedEmail(false);
             }
         }
     }
@@ -189,13 +197,14 @@ const ProfileAccountMainComponent = (props) => {
                     <BasicInformationComponent
                         userInfo={userRdx?.info}
                         verifiedPhoneNumber={verifiedPhoneNumber}
-                        verifiedEmail={verifiedEmail}
+                        isVerifiedEmail={isVerifiedEmail}
 
                         onSubmitUpdateUserInfo={__user.submit.updateInfo}
-                        onActionGetEmailAuthNumber={(email) => __user.req.getEmailAuthNumber(email)}
+                        onActionGetEmailAuthNumber={__user.req.getEmailAuthNumber}
                         onActionVerifyEmailAuthNumber={__user.req.verifyEmailAuthNumber}
                         onActionGetPhoneAuthNumber={__user.req.getPhoneAuthNumber}
                         onActionVerifyPhoneAuthNumber={__user.req.verifyPhoneAuthNumber}
+                        onActionResetVerifiedEmail={__user.action.onActionResetVerifiedEmail}
                     ></BasicInformationComponent>
                     <LineBreakerBottom
                         lineColor={'#e0e0e0'}

--- a/component/profile/account/index.js
+++ b/component/profile/account/index.js
@@ -25,7 +25,7 @@ const ProfileAccountMainComponent = (props) => {
     const [snackbarSeverity, setSnackbarSeverity] = useState('info');
     
     const [isVerifiedEmail, setIsVerifiedEmail] = useState(false);
-    const [verifiedPhoneNumber, setVerifiedPhoneNumber] = useState(null);
+    const [isVerifiedPhoneNumber, setIsVerifiedPhoneNumber] = useState(false);
 
     const __user = {
         req: {
@@ -95,7 +95,7 @@ const ProfileAccountMainComponent = (props) => {
                     if (res?.status === 200 && res?.data?.message === 'success') {
                         setSnackbarSeverity('success');
                         _onSnackbarOpen('인증되었습니다.');
-                        setVerifiedPhoneNumber(phoneNumber);
+                        setIsVerifiedPhoneNumber(true);
                     }
                 }).catch(err => {
                     let res = err?.response;
@@ -107,7 +107,6 @@ const ProfileAccountMainComponent = (props) => {
 
                     setSnackbarSeverity('error');
                     _onSnackbarOpen(res?.data?.memo);
-                    setVerifiedPhoneNumber(null);
                 });
             },
             getEmailAuthNumber: async (email) => {
@@ -115,7 +114,6 @@ const ProfileAccountMainComponent = (props) => {
                     if (res?.status === 200 && res?.data?.message === 'success') {
                         setSnackbarSeverity('success');
                         _onSnackbarOpen('인증 요청되었습니다.');
-                        setIsVerifiedEmail(false);
                     }
                 }).catch(err => {
                     let res = err?.response;
@@ -153,7 +151,8 @@ const ProfileAccountMainComponent = (props) => {
             updateInfo: async (body) => {
                 let data = {
                     ...body,
-                    verifiedEmail : isVerifiedEmail
+                    verifiedEmail : isVerifiedEmail,
+                    verifiedPhoneNumber : isVerifiedPhoneNumber
                 }
                 await __user.req.updateInfo(data);
                 await __user.req.fetchData();
@@ -166,6 +165,21 @@ const ProfileAccountMainComponent = (props) => {
         action: {
             onActionResetVerifiedEmail: () => {
                 setIsVerifiedEmail(false);
+            },
+            onActionResetVerifiedPhoneNumber: () => {
+                setIsVerifiedPhoneNumber(false);
+            },
+            onActionGetEmailAuthNumber: async (email) => {
+                await __user.req.getEmailAuthNumber(email);
+            },
+            onActionVerifyEmailAuthNumber: async (email, authNumber) => {
+                await __user.req.verifyEmailAuthNumber(email, authNumber);
+            },
+            onActionGetPhoneAuthNumber: async (phoneNumber) => {
+                await __user.req.getPhoneAuthNumber(phoneNumber);
+            },
+            onActionVerifyPhoneAuthNumber: async (phoneNumber, authNumber) => {
+                await __user.req.verifyPhoneAuthNumber(phoneNumber, authNumber);
             }
         }
     }
@@ -196,15 +210,16 @@ const ProfileAccountMainComponent = (props) => {
                     <HeadComponent></HeadComponent>
                     <BasicInformationComponent
                         userInfo={userRdx?.info}
-                        verifiedPhoneNumber={verifiedPhoneNumber}
                         isVerifiedEmail={isVerifiedEmail}
+                        isVerifiedPhoneNumber={isVerifiedPhoneNumber}
 
                         onSubmitUpdateUserInfo={__user.submit.updateInfo}
-                        onActionGetEmailAuthNumber={__user.req.getEmailAuthNumber}
-                        onActionVerifyEmailAuthNumber={__user.req.verifyEmailAuthNumber}
-                        onActionGetPhoneAuthNumber={__user.req.getPhoneAuthNumber}
-                        onActionVerifyPhoneAuthNumber={__user.req.verifyPhoneAuthNumber}
+                        onActionGetEmailAuthNumber={__user.action.onActionGetEmailAuthNumber}
+                        onActionVerifyEmailAuthNumber={__user.action.onActionVerifyEmailAuthNumber}
+                        onActionGetPhoneAuthNumber={__user.action.onActionGetPhoneAuthNumber}
+                        onActionVerifyPhoneAuthNumber={__user.action.onActionVerifyPhoneAuthNumber}
                         onActionResetVerifiedEmail={__user.action.onActionResetVerifiedEmail}
+                        onActionResetVerifiedPhoneNumber={__user.action.onActionResetVerifiedPhoneNumber}
                     ></BasicInformationComponent>
                     <LineBreakerBottom
                         lineColor={'#e0e0e0'}


### PR DESCRIPTION
#### [ 변경사항 ]

1)
* 이메일 변경 버튼 선택 시 email input창 활성화 -> 인증번호 요청 버튼 선택 시 인증번호 input창 표시.
* 인증번호 인증 성공 시 verifiedEmail 값 true, 실패 시 verifiedEmail 값 false 설정.
* 이 verifiedEmail을 회원정보 수정 시 dto에 넣는다. -> 서버에서 이메일 인증 여부 필드로 사용됨.

2)
* 회원 수정 완료 시 인증번호 입력창 hidden설정을 onActionResetEmailAuth함수를 이용

3) 
* 전화번호 인증도 이메일 인증과 같이 동작하도록 변경
* 하위 컴포넌트에서 api request호출하지 않고, api요청 전 처리를 위해 action을 먼저 호출
-----